### PR TITLE
Refactor avl.zig to use 'const' instead of 'var' to be in line with zig versions 0.12 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # zigavl
 A self-balancing binary [AVL](https://en.wikipedia.org/wiki/AVL_tree) tree written in Zig.
 
+# Presentation
+To use this library, you need at least Zig 0.13.x.
+
 ## Badges
 
 ![Build Status](https://img.shields.io/github/actions/workflow/status/ultd/base58-zig/test.yml?branch=main)

--- a/build.zig
+++ b/build.zig
@@ -8,19 +8,19 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addStaticLibrary(.{
         .name = package_name,
-        .root_source_file = .{ .path = package_path },
+        .root_source_file = .{ .src_path = .{ .owner = b,  .sub_path = package_path }},
         .target = target,
         .optimize = optimize,
     });
 
     _ = b.addModule(package_name, .{
-        .root_source_file = .{ .path = package_path },
+        .root_source_file = .{ .src_path = .{ .owner = b,  .sub_path = package_path }},
     });
 
     b.installArtifact(lib);
 
     const main_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/tests.zig" },
+        .root_source_file = .{ .src_path = .{ .owner = b,  .sub_path = "src/tests.zig" }},
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -14,8 +14,7 @@ pub fn build(b: *std.Build) void {
     });
 
     _ = b.addModule(package_name, .{
-        .source_file = .{ .path = package_path },
-        .dependencies = &.{},
+        .root_source_file = .{ .path = package_path },
     });
 
     b.installArtifact(lib);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,4 +2,5 @@
     .name = "zigavl",
     .version = "0.1.0",
     .dependencies = .{},
+    .paths = .{""},
 }

--- a/src/avl.zig
+++ b/src/avl.zig
@@ -8,9 +8,9 @@ const direction = enum {
 
     fn invert(self: direction) direction {
         switch (self) {
-        .left => return .right,
-        .right => return .left,
-        .center => return .center,
+            .left => return .right,
+            .right => return .left,
+            .center => return .center,
         }
     }
 };
@@ -76,17 +76,17 @@ fn makePtrLocationType(comptime K: type, comptime V: type, comptime Tags: type) 
 
         fn child(self: *const Self, comptime dir: direction) ?Self {
             switch (dir) {
-            .left => return self.ptr.*.left,
-            .right => return self.ptr.*.right,
-            else => unreachable,
+                .left => return self.ptr.*.left,
+                .right => return self.ptr.*.right,
+                else => unreachable,
             }
         }
 
         fn setChild(self: *Self, comptime dir: direction, loc: ?Self) void {
             switch (dir) {
-            .left => self.ptr.*.left = loc,
-            .right => self.ptr.*.right = loc,
-            else => unreachable,
+                .left => self.ptr.*.left = loc,
+                .right => self.ptr.*.right = loc,
+                else => unreachable,
             }
         }
 
@@ -152,7 +152,7 @@ pub const Options = struct {
     // countChildren, if set, enables children counts for every node of the tree.
     // the number of children allows to locate a node by its position with a guaranteed complexity O(logn).
     countChildren: bool = false,
-    };
+};
 
 // Tree is a generic avl tree.
 // AVL tree (https://en.wikipedia.org/wiki/AVL_tree) is a self-balancing binary search tree.
@@ -170,9 +170,9 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
     return struct {
         const Self = @This();
         const Tags = if (options.countChildren)
-        struct { childrenCount: u32 = 0 }
+            struct { childrenCount: u32 = 0 }
         else
-        struct {};
+            struct {};
 
         const Cache = locationCache(K, V, Tags);
         const Location = Cache.Location;
@@ -181,12 +181,12 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         const LocateResult = struct {
             loc: ?Location,
             dir: direction,
-            };
+        };
 
         pub const Entry = struct {
             k: K,
             v: *V,
-            };
+        };
 
         fn goLeft(loc: Location) Location {
             var l = loc;
@@ -200,7 +200,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn goRight(loc: Location) Location {
             var r = loc;
             while (true) {
-                const  right = r.child(.right) orelse break;
+                const right = r.child(.right) orelse break;
                 r = right;
             }
             return r;
@@ -261,12 +261,12 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
             var parent = l.parent() orelse return null;
             const dir = childDir(parent, l);
             switch (dir) {
-            .left => {
-                const right = parent.child(.right) orelse return parent;
-                return goLeftRight(right);
-            },
-            .right => return parent,
-            else => unreachable,
+                .left => {
+                    const right = parent.child(.right) orelse return parent;
+                    return goLeftRight(right);
+                },
+                .right => return parent,
+                else => unreachable,
             }
         }
 
@@ -296,18 +296,18 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
 
         fn childAt(loc: Location, dir: direction) ?Location {
             switch (dir) {
-            .left => return loc.child(.left),
-            .right => return loc.child(.right),
-            else => unreachable,
+                .left => return loc.child(.left),
+                .right => return loc.child(.right),
+                else => unreachable,
             }
         }
 
         fn setChildAt(parent: Location, dir: direction, child: ?Location) void {
             var p = parent;
             switch (dir) {
-            .left => p.setChild(.left, child),
-            .right => p.setChild(.right, child),
-            else => unreachable,
+                .left => p.setChild(.left, child),
+                .right => p.setChild(.right, child),
+                else => unreachable,
             }
         }
 
@@ -407,7 +407,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
             const min = self.min orelse return;
             var loc = goLeftRight(min);
             while (true) {
-                const  l = loc orelse break;
+                const l = loc orelse break;
                 const next = nextPostOrderLocation(l);
                 self.lc.destroy(l);
                 loc = next;
@@ -438,7 +438,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         pub const InsertResult = struct {
             inserted: bool,
             v: *V,
-            };
+        };
 
         // getOrEmplace inserts a new kv pair into the tree.
         //  - if tree already contains 'k', the function returns InsertResult{.inserted = false, .v = ptr_to_existing_value}
@@ -500,30 +500,30 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn insertNew(self: *Self, where: LocateResult, new_loc: Location) void {
             self.length += 1;
             switch (where.dir) {
-            .left, .right => {
-                var l = where.loc orelse unreachable;
-                reparent(l, where.dir, new_loc);
-                if (where.dir == .left and l.eq(self.min.?)) {
+                .left, .right => {
+                    var l = where.loc orelse unreachable;
+                    reparent(l, where.dir, new_loc);
+                    if (where.dir == .left and l.eq(self.min.?)) {
+                        self.min = new_loc;
+                    } else if (where.dir == .right and l.eq(self.max.?)) {
+                        self.max = new_loc;
+                    }
+                    if (l.recalcHeight()) {
+                        if (options.countChildren) {
+                            recalcCounts(l);
+                        }
+                        self.checkBalance(l.parent(), false);
+                    } else {
+                        if (options.countChildren) {
+                            updateCounts(l);
+                        }
+                    }
+                },
+                .center => {
+                    self.root = new_loc;
                     self.min = new_loc;
-                } else if (where.dir == .right and l.eq(self.max.?)) {
                     self.max = new_loc;
-                }
-                if (l.recalcHeight()) {
-                    if (options.countChildren) {
-                        recalcCounts(l);
-                    }
-                    self.checkBalance(l.parent(), false);
-                } else {
-                    if (options.countChildren) {
-                        updateCounts(l);
-                    }
-                }
-            },
-            .center => {
-                self.root = new_loc;
-                self.min = new_loc;
-                self.max = new_loc;
-            },
+                },
             }
         }
 
@@ -678,8 +678,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         // at returns a an entry at the ith position of the sorted array.
         // Panics if position >= tree.Len().
         // Time complexity:
-        //	O(logn) - if children node counts are enabled.
-        //	O(n) - otherwise.
+        //> O(logn) - if children node counts are enabled.
+        //> O(n) - otherwise.
         pub fn at(self: *Self, pos: usize) Entry {
             var loc = self.locateAt(pos);
             return Entry{
@@ -691,8 +691,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         // ascendAt returns an iterator pointing to the ith element.
         // Panics if position >= tree.Len().
         // Time complexity:
-        //	O(logn) - if children node counts are enabled.
-        //	O(n) - otherwise.
+        //> O(logn) - if children node counts are enabled.
+        //> O(n) - otherwise.
         pub fn ascendAt(self: *Self, pos: usize) Iterator {
             const loc = self.locateAt(pos);
             return Iterator{
@@ -705,13 +705,13 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         pub const KV = struct {
             Key: K,
             Value: V,
-            };
+        };
 
         // deleteAt deletes a node at the given position.
         // Panics if position >= tree.Len().
         // Time complexity:
-        //	O(logn) - if children node counts are enabled.
-        //	O(n) - otherwise.
+        //> O(logn) - if children node counts are enabled.
+        //> O(n) - otherwise.
         pub fn deleteAt(self: *Self, pos: usize) KV {
             var loc = self.locateAt(pos);
             const kv = KV{
@@ -736,31 +736,31 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                 const heightChanged = l.recalcHeight();
                 const parent = l.parent();
                 switch (l.balance()) {
-                -2 => {
-                    switch (l.child(.left).?.balance()) {
-                    -1, 0 => self.rr(l),
-                    1 => self.lr(l),
-                    else => unreachable,
-                    }
-                },
-                2 => {
-                    switch (l.child(.right).?.balance()) {
-                    -1 => self.rl(l),
-                    0, 1 => self.ll(l),
-                    else => unreachable,
-                    }
-                },
-                else => {
-                    if (!heightChanged and !all_way_up) {
-                        if (options.countChildren) {
-                            updateCounts(l);
+                    -2 => {
+                        switch (l.child(.left).?.balance()) {
+                            -1, 0 => self.rr(l),
+                            1 => self.lr(l),
+                            else => unreachable,
                         }
-                        return;
-                    }
-                    if (options.countChildren) {
-                        recalcCounts(l);
-                    }
-                },
+                    },
+                    2 => {
+                        switch (l.child(.right).?.balance()) {
+                            -1 => self.rl(l),
+                            0, 1 => self.ll(l),
+                            else => unreachable,
+                        }
+                    },
+                    else => {
+                        if (!heightChanged and !all_way_up) {
+                            if (options.countChildren) {
+                                updateCounts(l);
+                            }
+                            return;
+                        }
+                        if (options.countChildren) {
+                            recalcCounts(l);
+                        }
+                    },
                 }
                 mutLoc = parent;
             }
@@ -882,18 +882,18 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                 var l = result.loc orelse break;
                 var next: ?Location = null;
                 switch (Comparer(k, l.data().k)) {
-                .lt => {
-                    next = l.child(.left);
-                    result.dir = .left;
-                },
-                .eq => {
-                    result.dir = .center;
-                    return result;
-                },
-                .gt => {
-                    next = l.child(.right);
-                    result.dir = .right;
-                },
+                    .lt => {
+                        next = l.child(.left);
+                        result.dir = .left;
+                    },
+                    .eq => {
+                        result.dir = .center;
+                        return result;
+                    },
+                    .gt => {
+                        next = l.child(.right);
+                        result.dir = .right;
+                    },
                 }
                 if (next == null) {
                     break;
@@ -904,7 +904,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         }
 
         fn shouldLocateAtLinearly(self: *Self, pos: usize) bool {
-            const  p = @min(pos, self.length - pos - 1);
+            const p = @min(pos, self.length - pos - 1);
             return p <= 8;
         }
 
@@ -982,17 +982,17 @@ test "tree getOrEmplace" {
         fn ctor(ptr: *i64, args: anytype) void {
             ptr.* = args;
         }
-        }.ctor;
+    }.ctor;
     while (i < 128) {
         const ir = try t.getOrEmplace(i, ctor, i);
         try std.testing.expect(ir.inserted);
         try std.testing.expectEqual(i, ir.v.*);
         try checkHeightAndBalance(
-                i64,
-                i64,
-                TreeType.Location,
-                TreeType.Comparer,
-                t.root,
+            i64,
+            i64,
+            TreeType.Location,
+            TreeType.Comparer,
+            t.root,
         );
         i += 1;
     }
@@ -1037,11 +1037,11 @@ test "tree insert" {
         try std.testing.expectEqual(i, max.?.v.*);
 
         try checkHeightAndBalance(
-                i64,
-                i64,
-                TreeType.Location,
-                TreeType.Comparer,
-                t.root,
+            i64,
+            i64,
+            TreeType.Location,
+            TreeType.Comparer,
+            t.root,
         );
 
         i += 1;
@@ -1061,11 +1061,11 @@ test "tree insert" {
         try std.testing.expect(!ir.inserted);
         try std.testing.expectEqual(i * 2, ir.v.*);
         try checkHeightAndBalance(
-                i64,
-                i64,
-                TreeType.Location,
-                TreeType.Comparer,
-                t.root,
+            i64,
+            i64,
+            TreeType.Location,
+            TreeType.Comparer,
+            t.root,
         );
         i -= 1;
     }
@@ -1449,7 +1449,7 @@ fn recalcHeightAndBalance(comptime K: type, comptime V: type, comptime L: type, 
     try std.testing.expectEqual(result.height, l.data().h);
     if (l.balance() < -1 or l.balance() > 1) {
         return error{
-        InvalidBalance,
+            InvalidBalance,
         }.InvalidBalance;
     }
     return result;

--- a/src/avl.zig
+++ b/src/avl.zig
@@ -8,9 +8,9 @@ const direction = enum {
 
     fn invert(self: direction) direction {
         switch (self) {
-            .left => return .right,
-            .right => return .left,
-            .center => return .center,
+        .left => return .right,
+        .right => return .left,
+        .center => return .center,
         }
     }
 };
@@ -24,7 +24,7 @@ fn makeNodeData(comptime K: type, comptime V: type, comptime Tags: type) type {
         h: u8 = 0,
 
         fn setHeight(self: *Self, h: u8) bool {
-            var old = self.h;
+            const old = self.h;
             self.h = h;
             return old != h;
         }
@@ -76,17 +76,17 @@ fn makePtrLocationType(comptime K: type, comptime V: type, comptime Tags: type) 
 
         fn child(self: *const Self, comptime dir: direction) ?Self {
             switch (dir) {
-                .left => return self.ptr.*.left,
-                .right => return self.ptr.*.right,
-                else => unreachable,
+            .left => return self.ptr.*.left,
+            .right => return self.ptr.*.right,
+            else => unreachable,
             }
         }
 
         fn setChild(self: *Self, comptime dir: direction, loc: ?Self) void {
             switch (dir) {
-                .left => self.ptr.*.left = loc,
-                .right => self.ptr.*.right = loc,
-                else => unreachable,
+            .left => self.ptr.*.left = loc,
+            .right => self.ptr.*.right = loc,
+            else => unreachable,
             }
         }
 
@@ -136,7 +136,7 @@ fn locationCache(comptime K: type, comptime V: type, comptime Tags: type) type {
         }
 
         fn create(self: *Self) !Location {
-            var node = try self.a.create(Location.Node);
+            const node = try self.a.create(Location.Node);
             node.* = Location.Node.init();
             return Location.init(node);
         }
@@ -152,7 +152,7 @@ pub const Options = struct {
     // countChildren, if set, enables children counts for every node of the tree.
     // the number of children allows to locate a node by its position with a guaranteed complexity O(logn).
     countChildren: bool = false,
-};
+    };
 
 // Tree is a generic avl tree.
 // AVL tree (https://en.wikipedia.org/wiki/AVL_tree) is a self-balancing binary search tree.
@@ -170,9 +170,9 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
     return struct {
         const Self = @This();
         const Tags = if (options.countChildren)
-            struct { childrenCount: u32 = 0 }
+        struct { childrenCount: u32 = 0 }
         else
-            struct {};
+        struct {};
 
         const Cache = locationCache(K, V, Tags);
         const Location = Cache.Location;
@@ -181,17 +181,17 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         const LocateResult = struct {
             loc: ?Location,
             dir: direction,
-        };
+            };
 
         pub const Entry = struct {
             k: K,
             v: *V,
-        };
+            };
 
         fn goLeft(loc: Location) Location {
             var l = loc;
             while (true) {
-                var left = l.child(.left) orelse break;
+                const left = l.child(.left) orelse break;
                 l = left;
             }
             return l;
@@ -200,7 +200,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn goRight(loc: Location) Location {
             var r = loc;
             while (true) {
-                var right = r.child(.right) orelse break;
+                const  right = r.child(.right) orelse break;
                 r = right;
             }
             return r;
@@ -212,8 +212,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                 return goLeft(r);
             }
             while (true) {
-                var parent = l.parent() orelse return null;
-                var dir = childDir(parent, l);
+                const parent = l.parent() orelse return null;
+                const dir = childDir(parent, l);
                 if (dir == .left or dir == .center) {
                     return parent;
                 }
@@ -227,8 +227,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                 return goRight(left);
             }
             while (true) {
-                var parent = l.parent() orelse return null;
-                var dir = childDir(parent, l);
+                const parent = l.parent() orelse return null;
+                const dir = childDir(parent, l);
                 if (dir == .right or dir == .center) {
                     return parent;
                 }
@@ -259,14 +259,14 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn nextPostOrderLocation(loc: Location) ?Location {
             var l = loc;
             var parent = l.parent() orelse return null;
-            var dir = childDir(parent, l);
+            const dir = childDir(parent, l);
             switch (dir) {
-                .left => {
-                    var right = parent.child(.right) orelse return parent;
-                    return goLeftRight(right);
-                },
-                .right => return parent,
-                else => unreachable,
+            .left => {
+                const right = parent.child(.right) orelse return parent;
+                return goLeftRight(right);
+            },
+            .right => return parent,
+            else => unreachable,
             }
         }
 
@@ -296,18 +296,18 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
 
         fn childAt(loc: Location, dir: direction) ?Location {
             switch (dir) {
-                .left => return loc.child(.left),
-                .right => return loc.child(.right),
-                else => unreachable,
+            .left => return loc.child(.left),
+            .right => return loc.child(.right),
+            else => unreachable,
             }
         }
 
         fn setChildAt(parent: Location, dir: direction, child: ?Location) void {
             var p = parent;
             switch (dir) {
-                .left => p.setChild(.left, child),
-                .right => p.setChild(.right, child),
-                else => unreachable,
+            .left => p.setChild(.left, child),
+            .right => p.setChild(.right, child),
+            else => unreachable,
             }
         }
 
@@ -404,11 +404,11 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         }
 
         pub fn deinit(self: *Self) void {
-            var min = self.min orelse return;
+            const min = self.min orelse return;
             var loc = goLeftRight(min);
             while (true) {
-                var l = loc orelse break;
-                var next = nextPostOrderLocation(l);
+                const  l = loc orelse break;
+                const next = nextPostOrderLocation(l);
                 self.lc.destroy(l);
                 loc = next;
             }
@@ -421,7 +421,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
 
         fn createNewNode(self: *Self, k: ?K, v: ?V) !Location {
             var new_loc = try self.lc.create();
-            var data_ptr = new_loc.data();
+            const data_ptr = new_loc.data();
             data_ptr.*.tags = .{};
             if (k) |kVal| {
                 data_ptr.*.k = kVal;
@@ -438,14 +438,14 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         pub const InsertResult = struct {
             inserted: bool,
             v: *V,
-        };
+            };
 
         // getOrEmplace inserts a new kv pair into the tree.
         //  - if tree already contains 'k', the function returns InsertResult{.inserted = false, .v = ptr_to_existing_value}
         //  - otherwise calls ctor with given args to initialise a newly created value.
         // Time complexity: O(logn).
         pub fn getOrEmplace(self: *Self, k: K, ctor: fn (v: *V, args: anytype) void, args: anytype) !InsertResult {
-            var res = self.locate(k);
+            const res = self.locate(k);
             if (res.loc) |l| {
                 if (res.dir == .center) {
                     return InsertResult{
@@ -477,7 +477,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         }
 
         fn doInsert(self: *Self, k: K, v: V, updateExisting: bool) !InsertResult {
-            var res = self.locate(k);
+            const res = self.locate(k);
             if (res.loc) |l| {
                 if (res.dir == .center) {
                     if (updateExisting) {
@@ -500,30 +500,30 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn insertNew(self: *Self, where: LocateResult, new_loc: Location) void {
             self.length += 1;
             switch (where.dir) {
-                .left, .right => {
-                    var l = where.loc orelse unreachable;
-                    reparent(l, where.dir, new_loc);
-                    if (where.dir == .left and l.eq(self.min.?)) {
-                        self.min = new_loc;
-                    } else if (where.dir == .right and l.eq(self.max.?)) {
-                        self.max = new_loc;
-                    }
-                    if (l.recalcHeight()) {
-                        if (options.countChildren) {
-                            recalcCounts(l);
-                        }
-                        self.checkBalance(l.parent(), false);
-                    } else {
-                        if (options.countChildren) {
-                            updateCounts(l);
-                        }
-                    }
-                },
-                .center => {
-                    self.root = new_loc;
+            .left, .right => {
+                var l = where.loc orelse unreachable;
+                reparent(l, where.dir, new_loc);
+                if (where.dir == .left and l.eq(self.min.?)) {
                     self.min = new_loc;
+                } else if (where.dir == .right and l.eq(self.max.?)) {
                     self.max = new_loc;
-                },
+                }
+                if (l.recalcHeight()) {
+                    if (options.countChildren) {
+                        recalcCounts(l);
+                    }
+                    self.checkBalance(l.parent(), false);
+                } else {
+                    if (options.countChildren) {
+                        updateCounts(l);
+                    }
+                }
+            },
+            .center => {
+                self.root = new_loc;
+                self.min = new_loc;
+                self.max = new_loc;
+            },
             }
         }
 
@@ -536,18 +536,18 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         // Returns the value associated with k, if the node was present in the tree.
         // Time complexity: O(logn).
         pub fn delete(self: *Self, k: K) ?V {
-            var res = self.locate(k);
+            const res = self.locate(k);
             if (res.dir != .center) {
                 return null;
             }
             var l = res.loc orelse return null;
-            var v = l.data().v;
+            const v = l.data().v;
             self.deleteLocation(l);
             return v;
         }
 
         fn deleteAndReplace(self: *Self, loc: Location) void {
-            var replacement = findReplacement(loc);
+            const replacement = findReplacement(loc);
             if (self.min) |min| {
                 if (loc.eq(min)) {
                     self.min = nextInOrderLocation(loc);
@@ -558,12 +558,12 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                     self.max = prevInOrderLocation(loc);
                 }
             }
-            var parent = loc.parent();
+            const parent = loc.parent();
             self.length -= 1;
             if (replacement) |rep| {
                 var replacement_parent = rep.parent().?;
                 var replacement_dir = childDir(replacement_parent, rep);
-                var inverted = replacement_dir.invert();
+                const inverted = replacement_dir.invert();
                 if (replacement_parent.eq(loc)) {
                     if (parent) |p| {
                         reparent(p, childDir(p, loc), rep);
@@ -574,7 +574,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                     self.checkBalance(rep, true);
                     return;
                 }
-                var replacement_child = childAt(rep, inverted);
+                const replacement_child = childAt(rep, inverted);
                 reparent(replacement_parent, replacement_dir, replacement_child);
                 if (parent) |p| {
                     reparent(p, childDir(p, loc), rep);
@@ -595,8 +595,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         }
 
         fn findReplacement(loc: Location) ?Location {
-            var left = loc.child(.left);
-            var right = loc.child(.right);
+            const left = loc.child(.left);
+            const right = loc.child(.right);
             if (left) |l| {
                 if (right) |r| {
                     if (l.data().h <= r.data().h) {
@@ -654,8 +654,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         // deleteIterator deletes an iterator from the tree and returns
         // an iterator to the next element.
         pub fn deleteIterator(self: *Self, it: Iterator) Iterator {
-            var loc = it.loc orelse return it;
-            var next = nextInOrderLocation(loc);
+            const loc = it.loc orelse return it;
+            const next = nextInOrderLocation(loc);
             self.deleteLocation(loc);
             return Iterator{
                 .loc = next,
@@ -666,7 +666,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         // get returns a value for key k.
         // Time complexity: O(logn).
         pub fn get(self: *Self, k: K) ?*V {
-            var res = self.locate(k);
+            const res = self.locate(k);
             if (res.dir == .center) {
                 if (res.loc) |loc| {
                     return &loc.data().v;
@@ -694,7 +694,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         //	O(logn) - if children node counts are enabled.
         //	O(n) - otherwise.
         pub fn ascendAt(self: *Self, pos: usize) Iterator {
-            var loc = self.locateAt(pos);
+            const loc = self.locateAt(pos);
             return Iterator{
                 .tree = self,
                 .loc = loc,
@@ -705,7 +705,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         pub const KV = struct {
             Key: K,
             Value: V,
-        };
+            };
 
         // deleteAt deletes a node at the given position.
         // Panics if position >= tree.Len().
@@ -714,7 +714,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         //	O(n) - otherwise.
         pub fn deleteAt(self: *Self, pos: usize) KV {
             var loc = self.locateAt(pos);
-            var kv = KV{
+            const kv = KV{
                 .Key = loc.data().k,
                 .Value = loc.data().v,
             };
@@ -733,34 +733,34 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
             var mutLoc = loc;
             while (true) {
                 var l = mutLoc orelse break;
-                var heightChanged = l.recalcHeight();
-                var parent = l.parent();
+                const heightChanged = l.recalcHeight();
+                const parent = l.parent();
                 switch (l.balance()) {
-                    -2 => {
-                        switch (l.child(.left).?.balance()) {
-                            -1, 0 => self.rr(l),
-                            1 => self.lr(l),
-                            else => unreachable,
-                        }
-                    },
-                    2 => {
-                        switch (l.child(.right).?.balance()) {
-                            -1 => self.rl(l),
-                            0, 1 => self.ll(l),
-                            else => unreachable,
-                        }
-                    },
-                    else => {
-                        if (!heightChanged and !all_way_up) {
-                            if (options.countChildren) {
-                                updateCounts(l);
-                            }
-                            return;
-                        }
+                -2 => {
+                    switch (l.child(.left).?.balance()) {
+                    -1, 0 => self.rr(l),
+                    1 => self.lr(l),
+                    else => unreachable,
+                    }
+                },
+                2 => {
+                    switch (l.child(.right).?.balance()) {
+                    -1 => self.rl(l),
+                    0, 1 => self.ll(l),
+                    else => unreachable,
+                    }
+                },
+                else => {
+                    if (!heightChanged and !all_way_up) {
                         if (options.countChildren) {
-                            recalcCounts(l);
+                            updateCounts(l);
                         }
-                    },
+                        return;
+                    }
+                    if (options.countChildren) {
+                        recalcCounts(l);
+                    }
+                },
                 }
                 mutLoc = parent;
             }
@@ -769,8 +769,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn rr(self: *Self, loc: Location) void {
             var l = loc;
             var left = l.child(.left) orelse unreachable;
-            var left_right = left.child(.right);
-            var parent = l.parent();
+            const left_right = left.child(.right);
+            const parent = l.parent();
             if (parent) |p| {
                 reparent(parent, childDir(p, l), left);
             } else {
@@ -793,14 +793,14 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
             var l = loc;
             var left = l.child(.left) orelse unreachable;
             var left_right = left.child(.right) orelse unreachable;
-            var parent = l.parent();
+            const parent = l.parent();
             if (parent) |p| {
                 reparent(parent, childDir(p, l), left_right);
             } else {
                 self.setRoot(left_right);
             }
-            var left_right_right = left_right.child(.right);
-            var left_right_left = left_right.child(.left);
+            const left_right_right = left_right.child(.right);
+            const left_right_left = left_right.child(.left);
 
             reparent(left_right, .right, l);
             reparent(left_right, .left, left);
@@ -823,15 +823,15 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
             var l = loc;
             var right = l.child(.right) orelse unreachable;
             var right_left = right.child(.left) orelse unreachable;
-            var parent = l.parent();
+            const parent = l.parent();
             if (parent) |p| {
                 reparent(parent, childDir(p, l), right_left);
             } else {
                 self.setRoot(right_left);
             }
 
-            var right_left_left = right_left.child(.left);
-            var right_left_right = right_left.child(.right);
+            const right_left_left = right_left.child(.left);
+            const right_left_right = right_left.child(.right);
 
             reparent(right_left, .left, l);
             reparent(right_left, .right, right);
@@ -853,8 +853,8 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         fn ll(self: *Self, loc: Location) void {
             var l = loc;
             var right = l.child(.right) orelse unreachable;
-            var right_left = right.child(.left);
-            var parent = l.parent();
+            const right_left = right.child(.left);
+            const parent = l.parent();
             if (parent) |p| {
                 reparent(parent, childDir(p, l), right);
             } else {
@@ -882,18 +882,18 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
                 var l = result.loc orelse break;
                 var next: ?Location = null;
                 switch (Comparer(k, l.data().k)) {
-                    .lt => {
-                        next = l.child(.left);
-                        result.dir = .left;
-                    },
-                    .eq => {
-                        result.dir = .center;
-                        return result;
-                    },
-                    .gt => {
-                        next = l.child(.right);
-                        result.dir = .right;
-                    },
+                .lt => {
+                    next = l.child(.left);
+                    result.dir = .left;
+                },
+                .eq => {
+                    result.dir = .center;
+                    return result;
+                },
+                .gt => {
+                    next = l.child(.right);
+                    result.dir = .right;
+                },
                 }
                 if (next == null) {
                     break;
@@ -904,7 +904,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
         }
 
         fn shouldLocateAtLinearly(self: *Self, pos: usize) bool {
-            var p = @min(pos, self.length - pos - 1);
+            const  p = @min(pos, self.length - pos - 1);
             return p <= 8;
         }
 
@@ -921,7 +921,7 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
             var loc = self.root.?;
             var p = pos;
             while (true) {
-                var left_count = leftCount(loc);
+                const left_count = leftCount(loc);
                 if (p == left_count) {
                     return loc;
                 }
@@ -941,7 +941,7 @@ fn i64Cmp(a: i64, b: i64) math.Order {
 }
 
 test "empty tree" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
@@ -953,7 +953,7 @@ test "empty tree" {
 }
 
 test "tree getOrInsert" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = Tree(i64, i64, i64Cmp);
     var t = TreeType.init(a);
     defer t.deinit();
@@ -973,7 +973,7 @@ test "tree getOrInsert" {
 }
 
 test "tree getOrEmplace" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = Tree(i64, i64, i64Cmp);
     var t = TreeType.init(a);
     defer t.deinit();
@@ -982,24 +982,24 @@ test "tree getOrEmplace" {
         fn ctor(ptr: *i64, args: anytype) void {
             ptr.* = args;
         }
-    }.ctor;
+        }.ctor;
     while (i < 128) {
-        var ir = try t.getOrEmplace(i, ctor, i);
+        const ir = try t.getOrEmplace(i, ctor, i);
         try std.testing.expect(ir.inserted);
         try std.testing.expectEqual(i, ir.v.*);
         try checkHeightAndBalance(
-            i64,
-            i64,
-            TreeType.Location,
-            TreeType.Comparer,
-            t.root,
+                i64,
+                i64,
+                TreeType.Location,
+                TreeType.Comparer,
+                t.root,
         );
         i += 1;
     }
 
     i = 0;
     while (i < 128) {
-        var v = t.get(i);
+        const v = t.get(i);
         try std.testing.expect(v != null);
         try std.testing.expectEqual(i, v.?.*);
         i += 1;
@@ -1007,7 +1007,7 @@ test "tree getOrEmplace" {
 
     i = 0;
     while (i < 128) {
-        var ir = try t.getOrEmplace(i, ctor, i * 2);
+        const ir = try t.getOrEmplace(i, ctor, i * 2);
         try std.testing.expect(!ir.inserted);
         try std.testing.expectEqual(i, ir.v.*);
         i += 1;
@@ -1015,33 +1015,33 @@ test "tree getOrEmplace" {
 }
 
 test "tree insert" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = Tree(i64, i64, i64Cmp);
     var t = TreeType.init(a);
     defer t.deinit();
     var i: i64 = 0;
     while (i < 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expectEqual(true, ir.inserted);
         try std.testing.expectEqual(i, ir.v.*);
 
-        var min = t.getMin();
+        const min = t.getMin();
         try std.testing.expect(min != null);
-        var exp: i64 = 0;
+        const exp: i64 = 0;
         try std.testing.expectEqual(exp, min.?.k);
         try std.testing.expectEqual(exp, min.?.v.*);
 
-        var max = t.getMax();
+        const max = t.getMax();
         try std.testing.expect(max != null);
         try std.testing.expectEqual(i, max.?.k);
         try std.testing.expectEqual(i, max.?.v.*);
 
         try checkHeightAndBalance(
-            i64,
-            i64,
-            TreeType.Location,
-            TreeType.Comparer,
-            t.root,
+                i64,
+                i64,
+                TreeType.Location,
+                TreeType.Comparer,
+                t.root,
         );
 
         i += 1;
@@ -1049,7 +1049,7 @@ test "tree insert" {
 
     i = 0;
     while (i < 128) {
-        var v = t.get(i);
+        const v = t.get(i);
         try std.testing.expect(v != null);
         try std.testing.expectEqual(i, v.?.*);
         i += 1;
@@ -1057,22 +1057,22 @@ test "tree insert" {
 
     i = 127;
     while (i >= 0) {
-        var ir = try t.insert(i, i * 2);
+        const ir = try t.insert(i, i * 2);
         try std.testing.expect(!ir.inserted);
         try std.testing.expectEqual(i * 2, ir.v.*);
         try checkHeightAndBalance(
-            i64,
-            i64,
-            TreeType.Location,
-            TreeType.Comparer,
-            t.root,
+                i64,
+                i64,
+                TreeType.Location,
+                TreeType.Comparer,
+                t.root,
         );
         i -= 1;
     }
 
     i = 0;
     while (i < 128) {
-        var v = t.get(i);
+        const v = t.get(i);
         try std.testing.expect(v != null);
         try std.testing.expectEqual(i * 2, v.?.*);
         i += 1;
@@ -1080,7 +1080,7 @@ test "tree insert" {
 }
 
 test "tree delete" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
@@ -1155,69 +1155,69 @@ test "tree delete" {
 }
 
 test "delete min" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i <= 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
     i = 0;
     while (i <= 128) {
-        var e = t.getMin();
+        const e = t.getMin();
         try std.testing.expectEqual(i, e.?.k);
         try std.testing.expectEqual(i, e.?.v.*);
         try std.testing.expectEqual(i, t.delete(i).?);
         i += 1;
     }
-    var exp_len: usize = 0;
+    const exp_len: usize = 0;
     try std.testing.expectEqual(exp_len, t.len());
 }
 
 test "delete max" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i <= 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
     i = 0;
     while (i <= 128) {
-        var e = t.getMax();
+        const e = t.getMax();
         try std.testing.expectEqual(128 - i, e.?.k);
         try std.testing.expectEqual(128 - i, e.?.v.*);
         try std.testing.expectEqual(128 - i, t.delete(128 - i).?);
         i += 1;
     }
-    var exp_len: usize = 0;
+    const exp_len: usize = 0;
     try std.testing.expectEqual(exp_len, t.len());
 }
 
 test "tree at_countChildren" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i <= 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
 
     i = 0;
     while (i <= 128) {
-        var e = t.at(@as(usize, @intCast(i)));
+        const e = t.at(@as(usize, @intCast(i)));
         try std.testing.expectEqual(i, e.k);
         try std.testing.expectEqual(i, e.v.*);
         i += 1;
@@ -1225,21 +1225,21 @@ test "tree at_countChildren" {
 }
 
 test "tree at_nocountChildren" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i <= 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
 
     i = 0;
     while (i <= 128) {
-        var e = t.at(@as(usize, @intCast(i)));
+        const e = t.at(@as(usize, @intCast(i)));
         try std.testing.expectEqual(i, e.k);
         try std.testing.expectEqual(i, e.v.*);
         i += 1;
@@ -1247,14 +1247,14 @@ test "tree at_nocountChildren" {
 }
 
 test "tree deleteAt" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i < 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
@@ -1263,7 +1263,7 @@ test "tree deleteAt" {
     i = 64;
     while (i < 128) {
         try std.testing.expectEqual(exp_len, t.len());
-        var kv = t.deleteAt(64);
+        const kv = t.deleteAt(64);
         try std.testing.expectEqual(i, kv.Key);
         try std.testing.expectEqual(i, kv.Value);
         i += 1;
@@ -1273,7 +1273,7 @@ test "tree deleteAt" {
     i = 0;
     while (i < 64) {
         try std.testing.expectEqual(exp_len, t.len());
-        var kv = t.deleteAt(0);
+        const kv = t.deleteAt(0);
         try std.testing.expectEqual(i, kv.Key);
         try std.testing.expectEqual(i, kv.Value);
         i += 1;
@@ -1283,21 +1283,21 @@ test "tree deleteAt" {
 }
 
 test "tree iterator" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i < 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
     var it = t.ascendFromStart();
     i = 0;
     while (i < 128) {
-        var e = it.value();
+        const e = it.value();
         try std.testing.expectEqual(i, e.?.k);
         try std.testing.expectEqual(i, e.?.v.*);
         it.next();
@@ -1308,7 +1308,7 @@ test "tree iterator" {
     it = t.descendFromEnd();
     i = 127;
     while (i >= 0) {
-        var e = it.value();
+        const e = it.value();
         try std.testing.expectEqual(i, e.?.k);
         try std.testing.expectEqual(i, e.?.v.*);
         it.prev();
@@ -1325,7 +1325,7 @@ test "tree iterator" {
     }
     i = 0;
     while (i < 64) {
-        var e = it.value();
+        const e = it.value();
         try std.testing.expectEqual(i + 64, e.?.k);
         try std.testing.expectEqual(i + 64, e.?.v.*);
         it = t.deleteIterator(it);
@@ -1335,7 +1335,7 @@ test "tree iterator" {
     it = t.ascendFromStart();
     i = 0;
     while (i < 64) {
-        var e = it.value();
+        const e = it.value();
         try std.testing.expectEqual(i, e.?.k);
         try std.testing.expectEqual(i, e.?.v.*);
         it = t.deleteIterator(it);
@@ -1346,14 +1346,14 @@ test "tree iterator" {
 }
 
 test "tree ascendAt" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
     var t = TreeType.init(a);
     defer t.deinit();
 
     var i: i64 = 0;
     while (i < 128) {
-        var ir = try t.insert(i, i);
+        const ir = try t.insert(i, i);
         try std.testing.expect(ir.inserted);
         i += 1;
     }
@@ -1396,11 +1396,11 @@ test "tree random" {
     defer a.free(arr);
     var i: i64 = 0;
     while (i < 10) {
-        var exp_len: usize = 0;
+        const exp_len: usize = 0;
         var r = std.rand.DefaultPrng.init(0);
         r.random().shuffle(i64, arr);
         for (arr) |val| {
-            var ir = try t.insert(val, val);
+            const ir = try t.insert(val, val);
             try std.testing.expect(ir.inserted);
             try std.testing.expectEqual(val, ir.v.*);
             try checkHeightAndBalance(i64, i64, TreeType.Location, TreeType.Comparer, t.root);
@@ -1437,19 +1437,19 @@ fn recalcHeightAndBalance(comptime K: type, comptime V: type, comptime L: type, 
     var result = recalcResult.init();
     var l = loc orelse return result;
     if (l.child(.left) != null) {
-        var lRes = try recalcHeightAndBalance(K, V, L, Cmp, l.child(.left));
+        const lRes = try recalcHeightAndBalance(K, V, L, Cmp, l.child(.left));
         result.height = 1 + lRes.height;
         result.l_count = lRes.l_count + lRes.r_count + 1;
     }
     if (l.child(.right) != null) {
-        var rRes = try recalcHeightAndBalance(K, V, L, Cmp, l.child(.right));
+        const rRes = try recalcHeightAndBalance(K, V, L, Cmp, l.child(.right));
         result.height = @max(result.height, 1 + rRes.height);
         result.r_count = rRes.r_count + rRes.l_count + 1;
     }
     try std.testing.expectEqual(result.height, l.data().h);
     if (l.balance() < -1 or l.balance() > 1) {
         return error{
-            InvalidBalance,
+        InvalidBalance,
         }.InvalidBalance;
     }
     return result;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -7,15 +7,15 @@ fn i64Cmp(a: i64, b: i64) math.Order {
 }
 
 test "test pub decls" {
-    var a = std.testing.allocator;
+    const a = std.testing.allocator;
     const TreeType = lib.Tree(i64, i64, i64Cmp);
     var t = TreeType.init(a);
     defer t.deinit();
     _ = try t.insert(0, 0);
     var it = t.ascendFromStart();
-    var min = t.getMin().?;
+    const min = t.getMin().?;
     try std.testing.expectEqual(it.value().?.k, min.k);
-    var max = t.getMax().?;
+    const max = t.getMax().?;
     it = t.descendFromEnd();
     try std.testing.expectEqual(it.value().?.k, max.k);
     try std.testing.expectEqual(@as(i64, 0), t.at(0).k);
@@ -71,7 +71,7 @@ test "tree example usage" {
         @panic("invalid delete result");
     }
     // delete by position
-    var kv = t.deleteAt(0);
+    const kv = t.deleteAt(0);
     if (kv.Key != 2 or kv.Value != 2) {
         @panic("invalid deleteAt result");
     }


### PR DESCRIPTION
I've been using your package and needed it to be compatible with version 0.12, so I forked it. If you are okay with these changes, feel free to review and merge them.

Maciek