### PR TITLE
src: fast deinit feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /zig-out
 /.vscode
 /.zig-cache
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To use this library, you need at least Zig 0.13.x.
 
 ## API
 ```zig
+// create tree type:
 pub const Options = struct {
     countChildren: bool = false,
 };

--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ To use this library, you need at least Zig 0.13.x.
 
 ## API
 ```zig
+pub const Options = struct {
+    countChildren: bool = false,
+};
 pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: K, b: K) math.Order, comptime options: Options) type
 pub fn Tree(comptime K: type, comptime V: type, comptime Cmp: fn (a: K, b: K) math.Order) type
 
 // init/deinit:
+pub const InitOptions = struct {
+    allowFastDeinit: enum { always, auto, never } = .never,
+};
 pub fn init(a: std.mem.Allocator) Self
+pub fn initWithOptions(a: std.mem.Allocator, io: InitOptions) Self
 pub fn deinit()
 
 // insert:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zigavl",
-    .version = "0.6.1",
+    .version = "0.7.0",
     .dependencies = .{},
     .paths = .{""},
 }

--- a/src/avl.zig
+++ b/src/avl.zig
@@ -423,10 +423,10 @@ pub fn TreeWithOptions(comptime K: type, comptime V: type, comptime Cmp: fn (a: 
 
         io: InitOptions,
         lc: Cache,
-        length: usize = 0,
-        root: ?Location = null,
-        min: ?Location = null,
-        max: ?Location = null,
+        length: usize,
+        root: ?Location,
+        min: ?Location,
+        max: ?Location,
 
         // init initializes the tree.
         pub fn init(a: std.mem.Allocator) Self {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,3 +2,4 @@ const avl = @import("./avl.zig");
 pub const Tree = avl.Tree;
 pub const TreeWithOptions = avl.TreeWithOptions;
 pub const Options = avl.Options;
+pub const InitOptions = avl.InitOptions;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9,7 +9,12 @@ fn i64Cmp(a: i64, b: i64) math.Order {
 test "test pub decls" {
     const a = std.testing.allocator;
     const TreeType = lib.Tree(i64, i64, i64Cmp);
-    var t = TreeType.init(a);
+    const options = lib.InitOptions{
+        .allowFastDeinit = .auto,
+    };
+    var aa = std.heap.ArenaAllocator.init(a);
+    defer aa.deinit();
+    var t = TreeType.initWithOptions(aa.allocator(), options);
     defer t.deinit();
     _ = try t.insert(0, 0);
     var it = t.ascendFromStart();
@@ -29,7 +34,7 @@ test "tree example usage" {
     defer _ = gpa.detectLeaks();
     // first, create an i64-->i64 tree
     const TreeType = lib.TreeWithOptions(i64, i64, i64Cmp, .{ .countChildren = true });
-    var t = TreeType.init(gpa.allocator());
+    var t = TreeType.initWithOptions(gpa.allocator(), .{ .allowFastDeinit = .auto });
     defer t.deinit();
     // add some elements
     var i: i64 = 10;


### PR DESCRIPTION
When possible, don't traverse the tree in `deinit()`, if the memory can be freed on the allocator level.
Useful for arena and fixed buffer allocators.
